### PR TITLE
IN-10164: fix headers for patch request

### DIFF
--- a/internal/spf/record.go
+++ b/internal/spf/record.go
@@ -110,7 +110,7 @@ func UpdateSPFRecord(rootDomain, flatSPF, url, authEmail, authKey string) error 
 	}
 	req.Header.Add("Content-Type", "application/json")
 	req.Header.Add("X-Auth-Email", authEmail)
-	req.Header.Add("X-Auth-Key", authKey)
+	req.Header.Add("Authorization", "Bearer "+authKey)
 
 	res, err := http.DefaultClient.Do(req)
 	if err != nil {


### PR DESCRIPTION
While testing tool in IN-10164 found that the PATCH request in `UpdateSPFRecord` was failing with status code 400. After some testing, found that the problem was the headers.