### PR TITLE
Include all directive from redirect

### DIFF
--- a/cmd/spf-flatten/main.go
+++ b/cmd/spf-flatten/main.go
@@ -74,7 +74,7 @@ func main() {
 
 	/// Flatten SPF record for input domain
 	r := spf.NewRootSPF(inputs.rootDomain, spf.NetLookup{}, inputs.keep)
-	if err = r.FlattenSPF(r.RootDomain, inputs.initialSPF); err != nil {
+	if err = r.FlattenSPF(r.RootDomain, inputs.initialSPF, true); err != nil {
 		slog.Error("Could not flatten SPF record for initial domain", "error", err)
 		os.Exit(1)
 	}

--- a/internal/spf/record.go
+++ b/internal/spf/record.go
@@ -36,7 +36,7 @@ func GetLogLevel(inputLevel string) (slog.Level, error) {
 func GetDomainSPFRecord(domain string, lookupIF Lookup) (string, error) {
 	txtRecords, err := lookupIF.LookupTXT(domain)
 	if err != nil {
-		return "", fmt.Errorf("could not look up SPF record for %s: %s\n", domain, err)
+		return "", fmt.Errorf("could not look up SPF record for %s: %s", domain, err)
 	}
 	for _, record := range txtRecords {
 		// TBD: check that only one SPF record lookupexists for domain and fail otherwise?


### PR DESCRIPTION
- To decide whether to populate the `all` directive during parsing, accept an `includeAll` bool instead of testing whether the record being parsed is the base domain's. For nested parsing other than redirects, set it to false.

- Remove newlines from error strings (per go-staticcheck).

- Update tests.

Fixes #25